### PR TITLE
BackEnd: add issues related api

### DIFF
--- a/backend/fixflow/models.py
+++ b/backend/fixflow/models.py
@@ -15,13 +15,18 @@ class Priority(models.Model):
     title = models.CharField(max_length=250)
 
 class Issues(models.Model):
+    class Status(models.TextChoices):
+        OPEN = "open", "Open"
+        IN_PROGRESS = "in_progress", "In Progress"
+        CLOSED = "closed", "Closed"
+
     id = models.AutoField(primary_key=True)
     date_created = models.DateTimeField(default=timezone.now)
     date_updated = models.DateTimeField(default=timezone.now)
     title = models.CharField(max_length=250)
     description = models.CharField(max_length=800)
     location = models.CharField(max_length=250)
+    status = models.CharField(max_length=20, choices=Status.choices, default=Status.OPEN)
     priority = models.ForeignKey(Priority,null=False,on_delete=models.SET_DEFAULT,default="TBD")
     requester = models.ForeignKey(CustomUser,null=False,on_delete=models.PROTECT,related_name='requested_issues') # CANNOT DELETE USER THAT OPENED AN ISSUE
     assigned = models.ForeignKey(CustomUser,null=False,on_delete=models.PROTECT,related_name='assigned_issues') # CANNOT DELETE USER THAT IS ASSIGNED TO AN ISSUE
-

--- a/backend/fixflow/urls.py
+++ b/backend/fixflow/urls.py
@@ -5,4 +5,8 @@ from . import views
 urlpatterns = [
     path('', views.index),
     path('login/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('all-issues/', views.tickets),
+    path('issue/<int:ticket_id>/', views.ticket_detail),
+    path('issues-new/', views.create_ticket),
+
 ]

--- a/backend/fixflow/views.py
+++ b/backend/fixflow/views.py
@@ -22,6 +22,48 @@ class MyTokenObtainPairSerializer(TokenObtainPairSerializer):
 class MyTokenObtainPairView(TokenObtainPairView):
     serializer_class = MyTokenObtainPairSerializer
 
+
+@api_view(['GET'])
+def tickets(request):
+    open_tickets = Issues.objects.filter(status=Issues.Status.OPEN)
+    serializer = issuesSerializer(open_tickets, many=True)
+    return Response(serializer.data, status=status.HTTP_200_OK)
+
+@api_view(['GET', 'PATCH'])
+def ticket_detail(request, ticket_id):
+    try:
+        ticket = Issues.objects.get(id=ticket_id)
+    except Issues.DoesNotExist:
+        return Response({"error": "Ticket not found"}, status=status.HTTP_404_NOT_FOUND)
+
+    if request.method == 'GET':
+        serializer = issuesSerializer(ticket)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    elif request.method == 'PATCH':
+        serializer = issuesSerializer(ticket, data=request.data, partial=True)
+
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_200_OK)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+    serializer = issuesSerializer(ticket)
+    return Response(serializer.data, status=status.HTTP_200_OK)
+
+@api_view(['POST'])
+def create_ticket(request):
+    serializer = issuesSerializer(data=request.data)
+
+    if serializer.is_valid():
+        serializer.save()
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
 """
 @api_view(['GET','POST','PATCH'])   # MUST - PICK ONE / MORE
 def FUNC_NAME(request):             # MUST - PICK FUNC NAME


### PR DESCRIPTION
Added API support for the following :
 - View all open tickets - <url>/all-issues
 
<img width="1271" height="614" alt="image" src="https://github.com/user-attachments/assets/a5893cbc-97c1-4ed5-9925-09485ad993b6" />

 - View details on specific ticket
 - update a ticket - <url>/issue/[issue-id]
 
<img width="1282" height="724" alt="image" src="https://github.com/user-attachments/assets/58531046-2612-4c6f-96e2-ad2bfedf055d" />

 - open a new ticket - <url>/issues-new
 
<img width="1327" height="712" alt="image" src="https://github.com/user-attachments/assets/07d407f4-cf55-4138-8d74-c1debd843a03" />
