### PR TITLE
Front/Login integration

### DIFF
--- a/FrontEnd/src/App.tsx
+++ b/FrontEnd/src/App.tsx
@@ -6,6 +6,8 @@ import IssueList from './components/issue-list/IssueList';
 import { APP_ROUTING_PATHS } from './app/constants';
 import './App.scss';
 import { Auth } from './app/auth/Auth';
+import { ProtectedLoginRoute } from './app/guards/ProtectedLoginRoute';
+import { ProtectedInnerAppRoute } from './app/guards/ProtectedInnerAppRoute';
 
 function App() {
   return (
@@ -13,13 +15,24 @@ function App() {
       <Auth>
         <Routes>
           <Route path={APP_ROUTING_PATHS.AUTH} >
-            <Route path={APP_ROUTING_PATHS.LOGIN} element={<Login />} />
+            <Route path={APP_ROUTING_PATHS.LOGIN} element={
+              <ProtectedLoginRoute>
+                <Login />
+              </ProtectedLoginRoute>
+            } />
             <Route
               path={APP_ROUTING_PATHS.AUTH}
               element={<Navigate to={`${APP_ROUTING_PATHS.LOGIN}`} replace />}
             />
           </Route>
-          <Route path={APP_ROUTING_PATHS.HOME} element={<Main />} >
+          <Route
+            path={APP_ROUTING_PATHS.HOME}
+            element={
+              <ProtectedInnerAppRoute>
+                <Main />
+              </ProtectedInnerAppRoute>
+            }
+          >
             <Route path={APP_ROUTING_PATHS.HOME} element={<HomeExamples />} />
             <Route path={APP_ROUTING_PATHS.ISSUES} element={<IssueList />} />
           </Route>

--- a/FrontEnd/src/app/auth/Auth.tsx
+++ b/FrontEnd/src/app/auth/Auth.tsx
@@ -21,10 +21,11 @@ export const Auth: React.FC<React.PropsWithChildren> = ({ children }) => {
         setItemInLocalStorage(AUTH_LOCAL_STORAGE_KEYS.ACCESS_TOKEN, access);
         setItemInLocalStorage(AUTH_LOCAL_STORAGE_KEYS.REFRESH_TOKEN, refresh);
         const userId = getUserIdFromToken(access);
+        // on success login get the user data and navigate to the issues page
         dispatch(getUserById({ id: userId }))
           .unwrap()
           .then(() => {
-            navigate(APP_ROUTING_PATHS.ISSUES);
+            navigate(`${APP_ROUTING_PATHS.HOME}/${APP_ROUTING_PATHS.ISSUES}`);
           })
       }
     },

--- a/FrontEnd/src/app/auth/login/Login.scss
+++ b/FrontEnd/src/app/auth/login/Login.scss
@@ -96,30 +96,46 @@
                     }
                 }
 
-                .submit-btn {
-                    width: 100%;
-                    padding: 20px;
-                    margin-top: 15px;
-                    background-color: $purple6;
-                    color: $purple1;
-                    border: none;
-                    border-radius: 12px;
-                    font-size: 1.3rem;
-                    font-weight: bold;
-                    cursor: pointer;
-                    transition: background-color 0.2s, transform 0.1s;
+                .submit-btn-wrapper {
+                    position: relative;
+                    margin-top: 42px;
 
-                    &:hover {
-                        background-color: $purple7;
+                    .login-request-error {
+                        position: absolute;
+                        bottom: calc(100% + 8px);
+                        left: 0;
+                        width: 100%;
+                        margin: 0;
+                        color: $stateError;
+                        font-size: 0.95rem;
+                        font-weight: 600;
+                        text-align: center;
                     }
 
-                    &:active {
-                        transform: scale(0.98);
-                    }
+                    .submit-btn {
+                        width: 100%;
+                        padding: 20px;
+                        background-color: $purple6;
+                        color: $purple1;
+                        border: none;
+                        border-radius: 12px;
+                        font-size: 1.3rem;
+                        font-weight: bold;
+                        cursor: pointer;
+                        transition: background-color 0.2s, transform 0.1s;
 
-                    &:disabled {
-                        opacity: 0.7;
-                        cursor: not-allowed;
+                        &:hover {
+                            background-color: $purple7;
+                        }
+
+                        &:active {
+                            transform: scale(0.98);
+                        }
+
+                        &:disabled {
+                            opacity: 0.7;
+                            cursor: not-allowed;
+                        }
                     }
                 }
 

--- a/FrontEnd/src/app/auth/login/Login.scss
+++ b/FrontEnd/src/app/auth/login/Login.scss
@@ -137,6 +137,19 @@
                             cursor: not-allowed;
                         }
                     }
+
+                    .submit-btn-content {
+                        display: inline-flex;
+                        align-items: center;
+                        justify-content: center;
+                        min-height: 24px;
+                        width: 100%;
+
+                        .login-btn-spinner-icon {
+                            color: $neutral1;
+                            font-size: 22px;
+                        }
+                    }
                 }
 
                 .forgot-password-wrapper {

--- a/FrontEnd/src/app/auth/login/Login.tsx
+++ b/FrontEnd/src/app/auth/login/Login.tsx
@@ -1,10 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import './Login.scss';
 import LoginPic from '../../../assets/images/LoginPic.jpg';
 import WelcomeMessage from './Welcome-Message/WelcomeMessage';
 import MotivationSentences from './Motivation-Message/MotivationSentences';
 import './Welcome-Message/WelcomeMessage.scss';
+import { useAppDispatch } from '../../store';
+import { loginRequest } from '../auth.store';
 
 const Picture = () => {
     return (
@@ -14,7 +16,7 @@ const Picture = () => {
     );
 };
 type LoginFormData = {
-    Username: string;
+    username: string;
     password: string;
 };
 
@@ -24,9 +26,14 @@ const Login = () => {
         handleSubmit,
         formState: { errors, isSubmitting },
     } = useForm<LoginFormData>();
+    const dispatch = useAppDispatch();
+    const [loginErrorMsg, setLoginErrorMsg] = useState<string | null>(null);
 
     const onSubmit = (data: LoginFormData) => {
-        console.log('Login data:', data);
+        setLoginErrorMsg(null);
+        dispatch(loginRequest(data))
+            .unwrap()
+            .catch(() => setLoginErrorMsg('Invalid username or password. Please try again.'));
     };
 
     return (
@@ -46,7 +53,7 @@ const Login = () => {
                             <label>Username</label>
                             <input
                                 type="text"
-                                {...register('Username', {
+                                {...register('username', {
                                     required: 'Username is required',
                                     minLength: {
                                         value: 3,
@@ -54,7 +61,7 @@ const Login = () => {
                                     },
                                 })}
                             />
-                            {errors.Username && <p className="error-text">{errors.Username.message}</p>}
+                            {errors.username && <p className="error-text">{errors.username.message}</p>}
                         </div>
 
                         <div className="input-group password-group">
@@ -64,17 +71,20 @@ const Login = () => {
                                 {...register('password', {
                                     required: 'Password is required',
                                     minLength: {
-                                        value: 6,
-                                        message: 'Password must be at least 6 characters',
+                                        value: 8,
+                                        message: 'Password must be at least 8 characters',
                                     },
                                 })}
                             />
                             {errors.password && <p className="error-text">{errors.password.message}</p>}
                         </div>
 
-                        <button type="submit" className="submit-btn" disabled={isSubmitting}>
-                            Login
-                        </button>
+                        <div className="submit-btn-wrapper">
+                            {loginErrorMsg && <p className="login-request-error">{loginErrorMsg}</p>}
+                            <button type="submit" className="submit-btn" disabled={isSubmitting}>
+                                Login
+                            </button>
+                        </div>
 
                         <div className="forgot-password-wrapper">
                             <button

--- a/FrontEnd/src/app/auth/login/Login.tsx
+++ b/FrontEnd/src/app/auth/login/Login.tsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { Spin } from 'antd';
+import { LoadingOutlined } from '@ant-design/icons';
 import './Login.scss';
 import LoginPic from '../../../assets/images/LoginPic.jpg';
 import WelcomeMessage from './Welcome-Message/WelcomeMessage';
 import MotivationSentences from './Motivation-Message/MotivationSentences';
 import './Welcome-Message/WelcomeMessage.scss';
-import { useAppDispatch } from '../../store';
+import { useAppDispatch, useAppSelector } from '../../store';
 import { loginRequest } from '../auth.store';
+import { EAPIStatus } from '../../../shared/api/models';
 
 const Picture = () => {
     return (
@@ -24,10 +27,15 @@ const Login = () => {
     const {
         register,
         handleSubmit,
-        formState: { errors, isSubmitting },
+        formState: { errors },
     } = useForm<LoginFormData>();
     const dispatch = useAppDispatch();
+    const { loginRes } = useAppSelector((state) => state.authStoreReducer);
+    const { getUserByIdRequest } = useAppSelector((state) => state.userStoreReducer);
     const [loginErrorMsg, setLoginErrorMsg] = useState<string | null>(null);
+    const isLoginPending = loginRes.status === EAPIStatus.PENDING;
+    const isUserInfoPending = getUserByIdRequest.status === EAPIStatus.PENDING;
+    const isSubmitLoading = isLoginPending || isUserInfoPending;
 
     const onSubmit = (data: LoginFormData) => {
         setLoginErrorMsg(null);
@@ -81,8 +89,14 @@ const Login = () => {
 
                         <div className="submit-btn-wrapper">
                             {loginErrorMsg && <p className="login-request-error">{loginErrorMsg}</p>}
-                            <button type="submit" className="submit-btn" disabled={isSubmitting}>
-                                Login
+                            <button type="submit" className="submit-btn" disabled={isSubmitLoading}>
+                                <span className="submit-btn-content">
+                                    {isSubmitLoading ? (
+                                        <Spin indicator={<LoadingOutlined className="login-btn-spinner-icon" spin />} />
+                                    ) : (
+                                        'Login'
+                                    )}
+                                </span>
                             </button>
                         </div>
 

--- a/FrontEnd/src/app/guards/ProtectedInnerAppRoute.tsx
+++ b/FrontEnd/src/app/guards/ProtectedInnerAppRoute.tsx
@@ -1,0 +1,15 @@
+import { FunctionComponent, ReactElement } from 'react';
+import { Navigate } from 'react-router-dom';
+import { APP_ROUTING_PATHS, AUTH_LOCAL_STORAGE_KEYS } from '../constants';
+
+interface IProps {
+  children: ReactElement;
+}
+
+export const ProtectedInnerAppRoute: FunctionComponent<IProps> = ({ children }) => {
+  const tokenLocalStorage = localStorage.getItem(AUTH_LOCAL_STORAGE_KEYS.ACCESS_TOKEN);
+
+  return tokenLocalStorage ? children : (
+    <Navigate to={`${APP_ROUTING_PATHS.AUTH}/${APP_ROUTING_PATHS.LOGIN}`} replace />
+  );
+};

--- a/FrontEnd/src/app/guards/ProtectedLoginRoute.tsx
+++ b/FrontEnd/src/app/guards/ProtectedLoginRoute.tsx
@@ -1,0 +1,14 @@
+import { FunctionComponent, ReactElement } from 'react';
+import { AUTH_LOCAL_STORAGE_KEYS } from '../constants';
+import { Navigate } from 'react-router-dom';
+
+interface IProps {
+  children: ReactElement;
+}
+
+// will wrap the auth routing - if there is token and userInfo with phone number navigate the user inside the app to the chat page
+export const ProtectedLoginRoute: FunctionComponent<IProps> = ({ children }) => {
+  const tokenLocalStorage = localStorage.getItem(AUTH_LOCAL_STORAGE_KEYS.ACCESS_TOKEN);
+
+  return tokenLocalStorage ? <Navigate to="/" replace /> : children;
+};

--- a/FrontEnd/src/app/guards/ProtectedLoginRoute.tsx
+++ b/FrontEnd/src/app/guards/ProtectedLoginRoute.tsx
@@ -6,7 +6,7 @@ interface IProps {
   children: ReactElement;
 }
 
-// will wrap the auth routing - if there is token and userInfo with phone number navigate the user inside the app to the chat page
+// will wrap the auth routing - if there is token navigate the user inside the app to the issues page
 export const ProtectedLoginRoute: FunctionComponent<IProps> = ({ children }) => {
   const tokenLocalStorage = localStorage.getItem(AUTH_LOCAL_STORAGE_KEYS.ACCESS_TOKEN);
 

--- a/FrontEnd/src/shared/store/user.store.ts
+++ b/FrontEnd/src/shared/store/user.store.ts
@@ -1,6 +1,6 @@
 import type { ActionReducerMapBuilder } from '@reduxjs/toolkit';
 import { createReducer } from '@reduxjs/toolkit';
-import { API_ROUTES, AUTH_LOCAL_STORAGE_KEYS } from '../../app/constants';
+import { API_ROUTES } from '../../app/constants';
 import { apiService, createApiThunk } from '../api/axios';
 import { APIRequestState, type IAPIRequestState } from '../api/models';
 import { createAPIReducerCases, type ApiDataStateType } from './utils';
@@ -22,7 +22,7 @@ const initialState: UserStoreState = {
 
 export const getUserById = createApiThunk(
   'user/userById',
-  (params?: {id?: number}) => apiService.get<IGetUserByIdResponse>(`${API_ROUTES.USERS}/${params?.id}`),
+  (params?: {id?: number}) => apiService.get<IGetUserByIdResponse>(`${API_ROUTES.USERS}${params?.id}/`),
 );
 
 export const getUsersThunk = createApiThunk(


### PR DESCRIPTION
Part of https://github.com/morielsh57/FixFlow/issues/22
### **Login integration**

**This PR includes:**
- On login submit, we dispatch the login request to the server.
- If login fails, we catch the error and show a clear error message to the user.
- If login succeeds, we dispatch a request to fetch the logged-in user info from the server.
- While login or user-info requests are pending, we show a white spinner inside the Login button to indicate loading.
- When user-info request is fulfilled, we navigate the user to the Issues page.

Guards:
- Added `ProtectedLoginRoute`: if an authenticated user opens the login page, they are redirected back to the inner app.
- Added `ProtectedInnerAppRoute`: unauthenticated users are redirected to login and cannot access inner app routes.

------------------------------------------------------

Future (not implemented yet):
- Add a top app header with a Logout button. For now, logged-in users must clear cache/storage to log out.
- Add a Signup page for self-registration. Currently, new users are created via Postman requests.