### PR TITLE
Front/Departments - Part 2 - Issues

### DIFF
--- a/FrontEnd/src/app/auth/signin-signup-page-wrapper/SignupSigninPageWrapper.scss
+++ b/FrontEnd/src/app/auth/signin-signup-page-wrapper/SignupSigninPageWrapper.scss
@@ -29,7 +29,8 @@
       align-self: stretch;
       flex: 1;
       min-width: 400px;
-
+      display: none;
+      
       .picture {
         width: 100%;
         object-fit: contain;

--- a/FrontEnd/src/app/auth/signup/Signup.tsx
+++ b/FrontEnd/src/app/auth/signup/Signup.tsx
@@ -16,7 +16,7 @@ type SignupFormData = {
   first_name: string;
   last_name: string;
   email: string;
-  department: number;
+  department?: number;
   phone_number: string;
   password: string;
   confirm_password: string;
@@ -44,7 +44,7 @@ const Signup = () => {
       first_name: '',
       last_name: '',
       email: '',
-      department: 3,
+      department: undefined,
       phone_number: '',
       password: '',
       confirm_password: '',
@@ -72,7 +72,7 @@ const Signup = () => {
         first_name: data.first_name,
         last_name: data.last_name,
         email: data.email,
-        department: data.department !== null ? Number(data.department) : null,
+        department: Number(data.department),
         phone_number: data.phone_number,
         password: data.password,
       }),
@@ -190,7 +190,7 @@ const Signup = () => {
                 searchSelect
                 onSearch={() => {}}
                 disabled={isDepartmentsPending}
-                placeholder={isDepartmentsPending ? 'Loading departments...' : 'Select a department'}
+                placeholder="Select your department"
                 options={departmentOptions}
                 onBlur={field.onBlur}
                 onChange={(nextValue) => {

--- a/FrontEnd/src/app/auth/signup/Signup.tsx
+++ b/FrontEnd/src/app/auth/signup/Signup.tsx
@@ -44,7 +44,7 @@ const Signup = () => {
       first_name: '',
       last_name: '',
       email: '',
-      department: 1,
+      department: 3,
       phone_number: '',
       password: '',
       confirm_password: '',
@@ -55,7 +55,7 @@ const Signup = () => {
   const isAutoLoginPending = loginRes.status === EAPIStatus.PENDING;
   const isDepartmentsPending = getDepartmentsRequest.status === EAPIStatus.PENDING;
   const isSubmitLoading = isSignupPending || isAutoLoginPending;
-  const departmentOptions: IAppSelectOption[] = departments.map((department) => ({
+  const departmentOptions: IAppSelectOption[] = departments.filter(department => department.title !== "TBD").map((department) => ({
     value: department.id,
     label: department.title,
     searchLabel: department.title,

--- a/FrontEnd/src/components/issue-list/IssueCard.tsx
+++ b/FrontEnd/src/components/issue-list/IssueCard.tsx
@@ -11,10 +11,12 @@ const IssueCard = ({ issue }: Props) => {
   const dispatch = useAppDispatch();
   const { user } = useAppSelector((state) => state.userStoreReducer);
 
-  const isAssignedToMe = Boolean(user?.id && issue.assigned.id === user.id);
-  const assigneeLabel = isAssignedToMe
-    ? 'Assigned to me'
-    : `${issue.assigned.first_name} ${issue.assigned.last_name}`;
+  const isAssignedToMe = Boolean(user?.id && issue.assigned?.id === user.id);
+  const assigneeLabel = !issue.assigned
+    ? 'Unassigned'
+    : isAssignedToMe
+      ? 'Assigned to me'
+      : `${issue.assigned.first_name} ${issue.assigned.last_name}`;
   const reporterLabel = `${issue.requester.first_name} ${issue.requester.last_name}`;
   const priorityLabel = issue.priority.title;
 

--- a/FrontEnd/src/components/issue-list/IssueList.scss
+++ b/FrontEnd/src/components/issue-list/IssueList.scss
@@ -85,6 +85,13 @@
   gap: 16px;
 }
 
+.issue-section__empty {
+  margin: 0;
+  color: $neutral6;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
 @media only screen and (max-width: 700px) {
   .issue-list-page {
     padding: 20px;

--- a/FrontEnd/src/components/issue-list/IssueList.tsx
+++ b/FrontEnd/src/components/issue-list/IssueList.tsx
@@ -42,7 +42,6 @@ const IssueList = () => {
     }
 
     return issues.filter((issue) => {
-      console.log('Checking issue:', issue.title, issue.department?.id);
       const isSameDepartment = issue.department?.id === userDepartmentId;
       const isUnassigned = !issue.assigned;
       const isNotClosed = issue.status.toLowerCase() !== 'closed';

--- a/FrontEnd/src/components/issue-list/IssueList.tsx
+++ b/FrontEnd/src/components/issue-list/IssueList.tsx
@@ -29,9 +29,26 @@ const IssueList = () => {
     }
 
     return issues.filter(
-      (issue) => issue.assigned.id === user.id || issue.requester.id === user.id,
+      (issue) => issue.assigned?.id === user.id || issue.requester.id === user.id,
     );
   }, [issues, user]);
+
+  const isManager = Boolean(user?.is_manager);
+  const userDepartmentId = user?.department?.id;
+
+  const unassignedDepartmentIssues = useMemo(() => {
+    if (!isManager || !userDepartmentId) {
+      return [];
+    }
+
+    return issues.filter((issue) => {
+      console.log('Checking issue:', issue.title, issue.department?.id);
+      const isSameDepartment = issue.department?.id === userDepartmentId;
+      const isUnassigned = !issue.assigned;
+      const isNotClosed = issue.status.toLowerCase() !== 'closed';
+      return isSameDepartment && isUnassigned && isNotClosed;
+    });
+  }, [isManager, issues, userDepartmentId]);
 
   const openIssues = useMemo(() => {
     return userIssues.filter((issue) => issue.status.toLowerCase() !== 'closed');
@@ -68,6 +85,23 @@ const IssueList = () => {
           </div>
         </div>
       </div>
+
+      {isManager && (
+        <section className="issue-section">
+          <div className="issue-section__header">
+            <h2 className="issue-section__title">Unassigned Department Issues</h2>
+          </div>
+          <div className="issue-section__list">
+            {unassignedDepartmentIssues.length > 0 ? (
+              unassignedDepartmentIssues.map((issue) => (
+                <IssueCard key={issue.id} issue={issue} />
+              ))
+            ) : (
+              <p className="issue-section__empty">No unassigned issues in your department.</p>
+            )}
+          </div>
+        </section>
+      )}
 
       <section className="issue-section">
         <div className="issue-section__header">

--- a/FrontEnd/src/components/issue-list/hooks/useIssueDetailsForm.ts
+++ b/FrontEnd/src/components/issue-list/hooks/useIssueDetailsForm.ts
@@ -13,11 +13,13 @@ import {
   IIssue,
   IIssueCreateReqPayload,
   IIssueDetailsFormValues,
+  IIssueUpdateReqPayload,
   IIssueOptimisticUpdatePayload,
   IIssuePriority,
   IIssueUpdateReqActionPayload,
   IssueModalMode,
 } from '../issue.types';
+import { IDepartment } from '../../../shared/store/departments/departments.types';
 import { IUser } from '../../../shared/store/user.types';
 import { showErrorAlert } from '../../../shared/utils/alerts.utils';
 
@@ -42,14 +44,15 @@ export const useIssueDetailsForm = ({
     updateIssueReqState,
   } = useAppSelector((state) => state.issuesReducer);
   const { userList, user } = useAppSelector((state) => state.userStoreReducer);
+  const { departments } = useAppSelector((state) => state.departmentsStoreReducer);
 
   const priorityList = priorityListRes.data?.data ?? [];
   const defaultPriorityId = priorityList[0]?.id ?? 1;
-  const defaultAssigneeId = userList[0]?.id ?? 1;
+  const defaultDepartmentId = user?.department?.id ?? departments[0]?.id ?? 1;
 
   const defaultValues = useMemo(
-    () => getFormDefaults(mode, issue, defaultPriorityId, defaultAssigneeId),
-    [mode, issue, defaultPriorityId, defaultAssigneeId],
+    () => getFormDefaults(mode, issue, defaultPriorityId, defaultDepartmentId),
+    [mode, issue, defaultPriorityId, defaultDepartmentId],
   );
 
   const latestValuesRef = useRef<IIssueDetailsFormValues>(defaultValues);
@@ -60,11 +63,27 @@ export const useIssueDetailsForm = ({
     handleSubmit,
     reset,
     control,
+    watch,
     formState,
   } = useForm<IIssueDetailsFormValues>({
     mode: 'onChange',
     defaultValues,
   });
+  const selectedDepartmentId = watch('department');
+  const loggedinUserDepartmentId = user?.department?.id;
+  const shouldShowAssignedField = Boolean(
+    user?.is_manager &&
+    loggedinUserDepartmentId &&
+    Number(selectedDepartmentId) === loggedinUserDepartmentId,
+  );
+
+  const usersFromSelectedDepartment = useMemo(() => {
+    if (!selectedDepartmentId) {
+      return [];
+    }
+
+    return userList.filter((person) => person.department?.id === Number(selectedDepartmentId));
+  }, [selectedDepartmentId, userList]);
 
   // reset the form data with defaultValues when the modal is opened or when the issue changes (in edit mode)
   useEffect(() => {
@@ -106,8 +125,9 @@ export const useIssueDetailsForm = ({
         value,
         priorityList,
         userList,
+        departments,
       );
-      const requestPayload = { [field]: value };
+      const requestPayload = { [field]: value } as IIssueUpdateReqPayload;
       const updateRequestArgs: IIssueUpdateReqActionPayload = {
         id: issue.id,
         payload: requestPayload,
@@ -122,7 +142,7 @@ export const useIssueDetailsForm = ({
           // TODO: revert the optimistic update by patching the field back to the original value
         });
     },
-    [dispatch, issue, mode, priorityList, userList],
+    [departments, dispatch, issue, mode, priorityList, userList],
   );
 
   const handleTextBlur = useCallback(
@@ -153,6 +173,13 @@ export const useIssueDetailsForm = ({
     [patchFieldIfNeeded],
   );
 
+  const handleDepartmentChange = useCallback(
+    (value: number) => {
+      patchFieldIfNeeded('department', value);
+    },
+    [patchFieldIfNeeded],
+  );
+
   const onCreateSubmit = handleSubmit((values) => {
     if (mode !== 'create' || !user?.id) {
       return;
@@ -163,10 +190,14 @@ export const useIssueDetailsForm = ({
       description: values.description,
       location: values.location,
       status: 'Open',
+      department: Number(values.department),
       priority: Number(values.priority),
-      assigned: Number(values.assigned),
       requester: user.id,
     };
+
+    if (values.assigned !== undefined && values.assigned !== null) {
+      payload.assigned = Number(values.assigned);
+    }
 
     const selectedPriority = priorityList.find(
       (priority) => priority.id === payload.priority,
@@ -174,6 +205,10 @@ export const useIssueDetailsForm = ({
 
     const selectedAssignee = userList.find(
       (person) => person.id === payload.assigned,
+    );
+
+    const selectedDepartment = departments.find(
+      (department) => department.id === payload.department,
     );
 
     const nowIsoDate = new Date().toISOString();
@@ -186,8 +221,9 @@ export const useIssueDetailsForm = ({
       location: payload.location,
       status: payload.status,
       priority: selectedPriority!,
-      assigned: selectedAssignee!,
+      assigned: selectedAssignee ?? null,
       requester: user,
+      department: selectedDepartment!,
     };
 
     dispatch(createIssueOptimisticAction(optimisticIssue));
@@ -209,10 +245,13 @@ export const useIssueDetailsForm = ({
     control,
     formState,
     priorityList,
-    userList,
+    departments,
+    usersFromSelectedDepartment,
+    shouldShowAssignedField,
     onCreateSubmit,
     handleTextBlur,
     handleStatusChange,
+    handleDepartmentChange,
     handlePriorityChange,
     handleAssignedChange,
     createIssueReqState,
@@ -225,7 +264,7 @@ const getFormDefaults = (
   mode: IssueModalMode,
   issue: IIssue | undefined,
   defaultPriorityId: number,
-  defaultAssigneeId: number,
+  defaultDepartmentId: number,
 ): IIssueDetailsFormValues => {
   if (mode === 'edit' && issue) {
     return {
@@ -233,8 +272,9 @@ const getFormDefaults = (
       description: issue.description,
       location: issue.location,
       status: issue.status,
+      department: issue.department?.id ?? defaultDepartmentId,
       priority: issue.priority.id,
-      assigned: issue.assigned.id,
+      assigned: issue.assigned?.id,
     };
   }
 
@@ -244,8 +284,9 @@ const getFormDefaults = (
     description: '',
     location: '',
     status: 'Open',
+    department: defaultDepartmentId,
     priority: defaultPriorityId,
-    assigned: defaultAssigneeId,
+    assigned: undefined,
   };
 };
 
@@ -258,6 +299,7 @@ const createOptimisticUpdatePayload = (
   value: string | number,
   priorityList: IIssuePriority[],
   userList: IUser[],
+  departments: IDepartment[],
 ): IIssueOptimisticUpdatePayload => {
   const dateUpdated = new Date().toISOString();
 
@@ -266,6 +308,10 @@ const createOptimisticUpdatePayload = (
   if (field === 'priority') {
     const priorityId = Number(value);
     payload.priority = priorityList.find((priority) => priority.id === priorityId)
+    return payload;
+  } else if (field === 'department') {
+    const departmentId = Number(value);
+    payload.department = departments.find((department) => department.id === departmentId);
     return payload;
   } else if (field === 'assigned') {
     const assignedId = Number(value);

--- a/FrontEnd/src/components/issue-list/hooks/useIssueDetailsForm.ts
+++ b/FrontEnd/src/components/issue-list/hooks/useIssueDetailsForm.ts
@@ -71,6 +71,7 @@ export const useIssueDetailsForm = ({
   });
   const selectedDepartmentId = watch('department');
   const loggedinUserDepartmentId = user?.department?.id;
+  const shouldShowDepartmentField = mode === 'create' || issue?.department?.title === "TBD" || Boolean(user?.is_manager);
   const shouldShowAssignedField = Boolean(
     user?.is_manager &&
     loggedinUserDepartmentId &&
@@ -246,6 +247,7 @@ export const useIssueDetailsForm = ({
     formState,
     priorityList,
     departments,
+    shouldShowDepartmentField,
     usersFromSelectedDepartment,
     shouldShowAssignedField,
     onCreateSubmit,

--- a/FrontEnd/src/components/issue-list/issue-details/issue-details-form/IssueDetailsForm.tsx
+++ b/FrontEnd/src/components/issue-list/issue-details/issue-details-form/IssueDetailsForm.tsx
@@ -18,6 +18,7 @@ const IssueDetailsForm = ({ mode, issue }: IssueDetailsFormProps) => {
     formState,
     priorityList,
     departments,
+    shouldShowDepartmentField,
     usersFromSelectedDepartment,
     shouldShowAssignedField,
     onCreateSubmit,
@@ -171,38 +172,40 @@ const IssueDetailsForm = ({ mode, issue }: IssueDetailsFormProps) => {
         </div>
       )}
 
-      <div className="issue-details-form-field">
-        <label className="issue-details-form-label" htmlFor="issue-department">
-          Department
-        </label>
-        <Controller
-          name="department"
-          control={control}
-          rules={{
-            required: 'Department is required.',
-          }}
-          render={({ field }) => (
-            <AppSelect
-              id="issue-department"
-              value={field.value}
-              className="issue-details-form-app-select"
-              searchSelect
-              onSearch={() => {}}
-              placeholder="Select a department"
-              options={departmentOptions}
-              onBlur={field.onBlur}
-              onChange={(nextValue) => {
-                const normalizedValue = Number(nextValue);
-                field.onChange(normalizedValue);
-                handleDepartmentChange(normalizedValue);
-              }}
-            />
+      {shouldShowDepartmentField && (
+        <div className="issue-details-form-field">
+          <label className="issue-details-form-label" htmlFor="issue-department">
+            Department
+          </label>
+          <Controller
+            name="department"
+            control={control}
+            rules={{
+              required: 'Department is required.',
+            }}
+            render={({ field }) => (
+              <AppSelect
+                id="issue-department"
+                value={field.value}
+                className="issue-details-form-app-select"
+                searchSelect
+                onSearch={() => {}}
+                placeholder="Select a department"
+                options={departmentOptions}
+                onBlur={field.onBlur}
+                onChange={(nextValue) => {
+                  const normalizedValue = Number(nextValue);
+                  field.onChange(normalizedValue);
+                  handleDepartmentChange(normalizedValue);
+                }}
+              />
+            )}
+          />
+          {formState.errors.department && (
+            <p className="issue-details-form-error">{formState.errors.department.message}</p>
           )}
-        />
-        {formState.errors.department && (
-          <p className="issue-details-form-error">{formState.errors.department.message}</p>
-        )}
-      </div>
+        </div>
+      )}
 
       <div className="issue-details-form-field">
         <label className="issue-details-form-label" htmlFor="issue-priority">

--- a/FrontEnd/src/components/issue-list/issue-details/issue-details-form/IssueDetailsForm.tsx
+++ b/FrontEnd/src/components/issue-list/issue-details/issue-details-form/IssueDetailsForm.tsx
@@ -17,10 +17,13 @@ const IssueDetailsForm = ({ mode, issue }: IssueDetailsFormProps) => {
     control,
     formState,
     priorityList,
-    userList,
+    departments,
+    usersFromSelectedDepartment,
+    shouldShowAssignedField,
     onCreateSubmit,
     handleTextBlur,
     handleStatusChange,
+    handleDepartmentChange,
     handlePriorityChange,
     handleAssignedChange,
     createIssueReqState,
@@ -69,7 +72,13 @@ const IssueDetailsForm = ({ mode, issue }: IssueDetailsFormProps) => {
     label: priority.title,
   }));
 
-  const assignedOptions: IAppSelectOption[] = userList.map((person) => ({
+  const departmentOptions: IAppSelectOption[] = departments.map((department) => ({
+    value: department.id,
+    label: department.title,
+    searchLabel: department.title,
+  }));
+
+  const assignedOptions: IAppSelectOption[] = usersFromSelectedDepartment.map((person) => ({
     value: person.id,
     searchLabel: `${person.first_name} ${person.last_name} ${person.username}`,
     label: `${person.first_name} ${person.last_name}`,
@@ -163,6 +172,39 @@ const IssueDetailsForm = ({ mode, issue }: IssueDetailsFormProps) => {
       )}
 
       <div className="issue-details-form-field">
+        <label className="issue-details-form-label" htmlFor="issue-department">
+          Department
+        </label>
+        <Controller
+          name="department"
+          control={control}
+          rules={{
+            required: 'Department is required.',
+          }}
+          render={({ field }) => (
+            <AppSelect
+              id="issue-department"
+              value={field.value}
+              className="issue-details-form-app-select"
+              searchSelect
+              onSearch={() => {}}
+              placeholder="Select a department"
+              options={departmentOptions}
+              onBlur={field.onBlur}
+              onChange={(nextValue) => {
+                const normalizedValue = Number(nextValue);
+                field.onChange(normalizedValue);
+                handleDepartmentChange(normalizedValue);
+              }}
+            />
+          )}
+        />
+        {formState.errors.department && (
+          <p className="issue-details-form-error">{formState.errors.department.message}</p>
+        )}
+      </div>
+
+      <div className="issue-details-form-field">
         <label className="issue-details-form-label" htmlFor="issue-priority">
           Priority
         </label>
@@ -188,36 +230,34 @@ const IssueDetailsForm = ({ mode, issue }: IssueDetailsFormProps) => {
         />
       </div>
 
-      <div className="issue-details-form-field">
-        <label className="issue-details-form-label" htmlFor="issue-assigned">
-          Assigned
-        </label>
-        <Controller
-          name="assigned"
-          control={control}
-          rules={{
-            required: 'Assigned user is required.',
-            min: 1,
-          }}
-          render={({ field }) => (
+      {shouldShowAssignedField && (
+        <div className="issue-details-form-field">
+          <label className="issue-details-form-label" htmlFor="issue-assigned">
+            Assigned (Optional)
+          </label>
+          <Controller
+            name="assigned"
+            control={control}
+            render={({ field }) => (
               <AppSelect
                 id="issue-assigned"
                 value={field.value}
                 className="issue-details-form-app-select"
                 searchSelect
-              onSearch={() => {}}
-              placeholder="Select a person"
-              options={assignedOptions}
-              onBlur={field.onBlur}
-              onChange={(nextValue) => {
-                const normalizedValue = Number(nextValue);
-                field.onChange(normalizedValue);
-                handleAssignedChange(normalizedValue);
-              }}
-            />
-          )}
-        />
-      </div>
+                onSearch={() => {}}
+                placeholder="Select a person"
+                options={assignedOptions}
+                onBlur={field.onBlur}
+                onChange={(nextValue) => {
+                  const normalizedValue = Number(nextValue);
+                  field.onChange(normalizedValue);
+                  handleAssignedChange(normalizedValue);
+                }}
+              />
+            )}
+          />
+        </div>
+      )}
 
       {isCreateMode ? (
         <button

--- a/FrontEnd/src/components/issue-list/issue.data.ts
+++ b/FrontEnd/src/components/issue-list/issue.data.ts
@@ -29,6 +29,7 @@ const mockIssueUsers: IUser[] = [
     email: 'emma@example.com',
     phone_number: '0500000001',
     department: null,
+    is_manager: true,
   },
   {
     id: 2,
@@ -38,6 +39,7 @@ const mockIssueUsers: IUser[] = [
     email: 'alice@example.com',
     phone_number: '0500000002',
     department: null,
+    is_manager: false,
   },
   {
     id: 3,
@@ -47,6 +49,7 @@ const mockIssueUsers: IUser[] = [
     email: 'david@example.com',
     phone_number: '0500000003',
     department: null,
+    is_manager: false,
   },
   {
     id: 4,
@@ -56,6 +59,7 @@ const mockIssueUsers: IUser[] = [
     email: 'lea@example.com',
     phone_number: '0500000004',
     department: null,
+    is_manager: true,
   },
 ];
 
@@ -71,6 +75,7 @@ export const mockIssues: IIssue[] = [
     priority: mockIssuePriorities[2],
     assigned: mockIssueUsers[0],
     requester: mockIssueUsers[0],
+    department: { id: 1, title: 'IT'},
   },
   {
     id: 2,
@@ -83,6 +88,7 @@ export const mockIssues: IIssue[] = [
     priority: mockIssuePriorities[1],
     assigned: mockIssueUsers[0],
     requester: mockIssueUsers[0],
+    department: { id: 1, title: 'IT'},
   },
   {
     id: 3,
@@ -95,6 +101,7 @@ export const mockIssues: IIssue[] = [
     priority: mockIssuePriorities[3],
     assigned: mockIssueUsers[0],
     requester: mockIssueUsers[0],
+    department: { id: 1, title: 'IT'},
   },
   {
     id: 4,
@@ -107,5 +114,6 @@ export const mockIssues: IIssue[] = [
     priority: mockIssuePriorities[0],
     assigned: mockIssueUsers[1],
     requester: mockIssueUsers[0],
+    department: { id: 1, title: 'IT'},
   },
 ];

--- a/FrontEnd/src/components/issue-list/issue.types.ts
+++ b/FrontEnd/src/components/issue-list/issue.types.ts
@@ -1,3 +1,4 @@
+import { IDepartment } from '../../shared/store/departments/departments.types';
 import { IUser } from '../../shared/store/user.types';
 
 export type IssueStatus = 'Open' | 'In Progress' | 'Closed';
@@ -13,8 +14,9 @@ export interface IIssue {
   date_created: string;
   date_updated: string;
   priority: IIssuePriority;
-  assigned: IUser;
+  assigned: IUser | null;
   requester: IUser;
+  department?: IDepartment;
 }
 
 export interface IIssuePriority {
@@ -34,8 +36,9 @@ export interface IIssueCreateReqPayloadWithoutRequester {
   description: string;
   location: string;
   status: IssueStatus;
+  department: number;
   priority: number;
-  assigned: number;
+  assigned?: number;
 }
 export interface IIssueCreateReqPayload extends IIssueCreateReqPayloadWithoutRequester {
   requester: number;
@@ -43,7 +46,9 @@ export interface IIssueCreateReqPayload extends IIssueCreateReqPayloadWithoutReq
 
 export interface IIssueUpdateReqPayload extends Partial<IIssueCreateReqPayloadWithoutRequester> {}
 
-export interface IIssueDetailsFormValues extends IIssueCreateReqPayloadWithoutRequester {}
+export interface IIssueDetailsFormValues extends Omit<IIssueCreateReqPayloadWithoutRequester, 'assigned'> {
+  assigned?: number;
+}
 
 export interface IIssueUpdateReqActionPayload {
   id: number;

--- a/FrontEnd/src/components/main/Main.tsx
+++ b/FrontEnd/src/components/main/Main.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from 'react-router-dom';
 import './Main.scss';
 import { useEffect } from 'react';
-import { useAppDispatch } from '../../app/store';
+import { store, useAppDispatch } from '../../app/store';
 import { getUserById, getUsersThunk } from '../../shared/store/user.store';
 import { getPriorityListReqAction } from '../issue-list/issues.store';
 import { getItemFromLocalStorage } from '../../shared/utils/localStorage.utils';
@@ -10,6 +10,7 @@ import { IUser } from '../../shared/store/user.types';
 import { logOut } from '../../shared/utils/logout';
 import { getUserIdFromToken } from '../../app/auth/auth.utils';
 import Header from '../../shared/layout/header/Header';
+import { getDepartmentsThunk } from '../../shared/store/departments/departments.store';
 
 export const Main = () => {
   const dispatch = useAppDispatch();
@@ -17,6 +18,9 @@ export const Main = () => {
   useEffect(() => {
     dispatch(getUsersThunk());
     dispatch(getPriorityListReqAction());
+    if(store.getState().departmentsStoreReducer.departments.length === 0) {
+      dispatch(getDepartmentsThunk());
+    }
     // on app load, check if user data is available in local storage, if not try to get it using the user id from local storage, if that also fails, log out the user
     const userData = getItemFromLocalStorage<IUser>(AUTH_LOCAL_STORAGE_KEYS.USER);
     if (!userData?.id) {

--- a/FrontEnd/src/shared/layout/header/Header.scss
+++ b/FrontEnd/src/shared/layout/header/Header.scss
@@ -10,11 +10,27 @@
   box-shadow: 0 4px 12px $neutral8;
 }
 
-.app-header--user {
-  margin: 0;
-  color: $neutral7;
-  font-size: 0.95rem;
-  font-weight: 600;
+.user-details-wrapper {
+  @include displayFlex(center, flex-start, column);
+  gap: 6px;
+
+  .header-user-name, 
+  .header-department-manager  {
+    margin: 0;
+    color: $neutral7;
+    font-size: 0.95rem;
+    font-weight: 600;
+
+    span {
+      color: $purple7;
+      font-weight: 700;
+    }
+  }
+
+  .header-department-manager {
+    font-size: 0.85rem;
+    font-weight: 500;
+  }
 }
 
 .app-header--logout-btn {
@@ -26,7 +42,13 @@
     padding: 14px 16px;
   }
 
-  .app-header--user {
-    font-size: 0.85rem;
-  }
+  .user-details-wrapper {
+    .header-user-name {
+      font-size: 0.85rem;
+    }
+
+    .header-department-manager {
+      font-size: 0.75rem;
+    }
+    }
 }

--- a/FrontEnd/src/shared/layout/header/Header.tsx
+++ b/FrontEnd/src/shared/layout/header/Header.tsx
@@ -19,7 +19,10 @@ const Header = () => {
 
   return (
     <header className="app-header">
-      <p className="app-header--user">Logged in as {getUserName()}</p>
+      <div className='user-details-wrapper'>
+        <p className="header-user-name">Logged in as <span>{getUserName()}</span></p>
+        {user?.is_manager && user?.department?.title && <p className="header-department-manager"><span>{user.department.title}</span> Department Manager</p>}
+      </div>
 
       <button type="button" className="app-header--logout-btn" onClick={logOut}>
         Logout

--- a/FrontEnd/src/shared/store/departments/departments.store.ts
+++ b/FrontEnd/src/shared/store/departments/departments.store.ts
@@ -13,7 +13,7 @@ export interface DepartmentsStoreState extends ApiDataStateType {
 
 const initialState: DepartmentsStoreState = {
   getDepartmentsRequest: APIRequestState.create<IGetDepartmentsResponse>(),
-  departments: [{id: 1, title: 'Default1'}, { id: 2, title: 'IT' }],
+  departments: [],
 };
 
 export const getDepartmentsThunk = createApiThunk(

--- a/FrontEnd/src/shared/store/user.types.ts
+++ b/FrontEnd/src/shared/store/user.types.ts
@@ -8,6 +8,7 @@ export interface IUser {
   email: string;
   phone_number: string;
   department: IDepartment | null;
+  is_manager: boolean;
 }
 
 export interface IGetUsersResponse {


### PR DESCRIPTION
Main changes:
Expose unassigned department issues to department managers, and provide an option for managers to assign those issues to a department employee.

- Assign tickets to a department instead of a specific user
- Each department manager sees the unassigned tickets related to their own department
- Only department manager can assign a ticket to a different department/employee on edit ticket.
